### PR TITLE
fix(cli): change version flag from -V to -v for standard CLI convention

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::process;
 #[derive(Parser)]
 #[command(name = "gitignore-gen")]
 #[command(version)]
+#[command(disable_version_flag = true)]
 #[command(about = "Generate .gitignore files based on project analysis")]
 #[command(long_about = "A CLI tool that analyzes your project structure and generates
 appropriate .gitignore files by detecting technologies and frameworks.
@@ -31,6 +32,10 @@ struct Cli {
     /// List available templates
     #[arg(short, long)]
     list: bool,
+
+    /// Print version
+    #[arg(short = 'v', long = "version", action = clap::ArgAction::Version)]
+    version: (),
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
Change the version short flag from uppercase -V to lowercase -v to follow the standard and widely-used convention across CLI tools (Git, npm, pip, cargo, etc.).

Summary of changes:
- Disable default version flag with disable_version_flag = true
- Add custom version argument with short = 'v'
- Keep --version as the long flag

Fixes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit `-v` and `--version` flags to retrieve CLI version information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Changed the version short flag from `-V` to `-v` to align with standard CLI conventions used by tools like Git, npm, pip, and cargo.

**Changes made:**
- Disabled clap's default version flag using `disable_version_flag = true`
- Added custom version argument with `short = 'v'` and `long = "version"`
- Maintained `--version` as the long flag option

**Impact:**
- Improves usability by following universal CLI conventions
- Users can now use `-v` instead of `-V` to check version
- No breaking changes to `--version` long flag

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is minimal, well-scoped, and follows standard CLI conventions. The implementation correctly disables the default version flag and creates a custom one with the conventional `-v` short flag. No logic changes, no new dependencies, and aligns with user expectations.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/main.rs | Changed version flag from `-V` to `-v` to follow standard CLI conventions |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as gitignore-gen CLI
    participant Clap as Clap Parser
    participant Main as Main Function

    User->>CLI: gitignore-gen -v
    CLI->>Clap: Parse arguments
    Note over Clap: disable_version_flag = true<br/>Custom version arg with short = 'v'
    Clap->>Clap: Match -v flag
    Clap->>Clap: Execute ArgAction::Version
    Clap->>User: Print version and exit
    
    Note over User,Main: Normal execution flow (when version not requested)
    User->>CLI: gitignore-gen [options]
    CLI->>Clap: Parse arguments
    Clap->>Main: Return parsed Cli struct
    Main->>Main: Process commands/options
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->